### PR TITLE
Support config precedence (like AWS CLI)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
 Lint/Eval:
   Enabled: false
 
@@ -25,6 +28,12 @@ Metrics/MethodLength:
 Metrics/PerceivedComplexity:
   Max: 15
 
+Performance/StringReplacement:
+  Enabled: false
+
+Style/Alias:
+  Enabled: false
+
 Style/BarePercentLiterals:
   Enabled: false
 
@@ -32,6 +41,12 @@ Style/ClassAndModuleChildren:
   Enabled: false
 
 Style/Documentation:
+  Enabled: false
+
+Style/MutableConstant:
+  Enabled: false
+
+Style/MultilineOperationIndentation:
   Enabled: false
 
 Style/StabbyLambdaParentheses:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 AWS credentials loader
 
+## awsecrets config precedence
+
+1. Command Line Options
+2. Environment Variables
+3. YAML file (secrets.yml)
+4. The AWS credentials file
+5. The CLI configuration file
+
+(See http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence)
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# awsecrets [![Gem](https://img.shields.io/gem/v/awsecrets.svg)](https://rubygems.org/gems/awsecrets)
+# awsecrets [![Gem](https://img.shields.io/gem/v/awsecrets.svg)](https://rubygems.org/gems/awsecrets) [![Travis](https://img.shields.io/travis/k1LoW/awsecrets.svg)](https://travis-ci.org/k1LoW/awsecrets)
 
 AWS credentials loader
 

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -31,7 +31,7 @@ module Awsecrets
     return unless @profile
     aws_config = AWSConfig.profiles[@profile]
     @region = aws_config.config_hash[:region] if aws_config
-    @credentials = Aws::SharedCredentials.new(profile_name: @profile) 
+    @credentials = Aws::SharedCredentials.new(profile_name: @profile)
   end
 
   def self.load_env

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -25,8 +25,6 @@ module Awsecrets
     Aws.config[:credentials] = @credentials
   end
 
-  private
-
   def self.load_command
     return unless @profile
     aws_config = AWSConfig.profiles[@profile]

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -4,26 +4,71 @@ require 'aws_config'
 require 'yaml'
 
 module Awsecrets
-  def self.load(profile: nil, secrets_path: 'secrets.yml')
-    profile = ENV['AWS_PROFILE'] if profile.nil?
-    if profile
-      # SharedCredentials
-      aws_config = AWSConfig.profiles[profile]
-      aws_config = AWSConfig.profiles['default'] unless aws_config
-      Aws.config[:region] = aws_config.config_hash[:region] if aws_config
-      Aws.config[:credentials] = Aws::SharedCredentials.new(profile_name: profile)
-    else
-      # secrets.yml
-      creds = YAML.load_file(secrets_path) if File.exist?(secrets_path)
-      return if creds.nil?
-      Aws.config.update({
-                          region: creds['region']
-                        }) if creds.include?('region')
-      Aws.config.update({
-                          credentials: Aws::Credentials.new(
-                            creds['aws_access_key_id'],
-                            creds['aws_secret_access_key'])
-                        }) if creds.include?('aws_access_key_id') && creds.include?('aws_secret_access_key')
+  def self.load(profile: nil, region: nil, secrets_path: 'secrets.yml')
+    @profile = profile
+    @secrets_path = secrets_path
+    @region = region
+    @credentials = nil
+
+    # 1. Command Line Options
+    load_command
+    # 2. Environment Variables
+    load_env
+    # 3. YAML file (secrets.yml)
+    load_yaml
+    # 4. The AWS credentials file
+    load_creds
+    # 5. The CLI configuration file
+    load_config
+
+    Aws.config[:region] = @region
+    Aws.config[:credentials] = @credentials
+  end
+
+  private
+
+  def self.load_command
+    return unless @profile
+    aws_config = AWSConfig.profiles[@profile]
+    @region = aws_config.config_hash[:region] if aws_config
+    @credentials = Aws::SharedCredentials.new(profile_name: @profile) 
+  end
+
+  def self.load_env
+    @region = ENV['AWS_REGION'] unless @region
+    @region = ENV['AWS_DEFAULT_REGION'] unless @region
+    if @credentials.nil? && ENV['AWS_PROFILE']
+      @credentials = Aws::SharedCredentials.new(profile_name: ENV['AWS_PROFILE'])
+      @profile = ENV['AWS_PROFILE']
     end
+    if @credentials.nil? && ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY']
+      @credentials = @credentials = Aws::Credentials.new(
+        ENV['AWS_ACCESS_KEY_ID'],
+        ENV['AWS_SECRET_ACCESS_KEY'])
+    end
+  end
+
+  def self.load_yaml
+    creds = YAML.load_file(@secrets_path) if File.exist?(@secrets_path)
+    if @region.nil? && creds
+      @region = creds['region'] if creds.include?('region')
+    end
+    if @credentials.nil? && creds && creds.include?('aws_access_key_id') && creds.include?('aws_secret_access_key')
+      @credentials = Aws::Credentials.new(
+        creds['aws_access_key_id'],
+        creds['aws_secret_access_key'])
+    end
+  end
+
+  def self.load_creds
+    return unless @credentials.nil?
+    @credentials = Aws::SharedCredentials.new(profile_name: nil)
+  end
+
+  def self.load_config
+    return unless @region.nil?
+    aws_config = AWSConfig.profiles[@profile]
+    aws_config = AWSConfig.profiles['default'] unless aws_config
+    @region = aws_config.config_hash[:region] if aws_config
   end
 end

--- a/spec/awsecrets_spec.rb
+++ b/spec/awsecrets_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pp'
 
 describe Awsecrets do
   let(:fixtures_path) do
@@ -15,25 +16,123 @@ describe Awsecrets do
     expect(Awsecrets::VERSION).not_to be nil
   end
 
-  it '--profile option' do
-    Awsecrets.load(profile: 'dev')
-    expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
-    expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
-    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+  context 'Configration' do
+    it 'load --profile option' do
+      Awsecrets.load(profile: 'dev')
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+    end
+
+    it 'load --region option' do
+      Awsecrets.load(region: 'OPTION_REGION')
+      expect(Aws.config[:region]).to eq('OPTION_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
+
+    it 'load secrets.yml' do
+      Awsecrets.load(secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
+      expect(Aws.config[:region]).to eq('YAML_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('YAML_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('YAML_SECRET_ACCESS_KEY')
+    end
+
+    it 'load AWS_PROIFLE' do
+      stub_const('ENV', { 'AWS_PROFILE' => 'dev' })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+    end
+
+    it 'load AWS_DEFAULT_PROIFLE' do
+      stub_const('ENV', { 'AWS_DEFAULT_PROFILE' => 'default' })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
+
+    it 'load AWS_REGION' do
+      stub_const('ENV', { 'AWS_REGION' => 'ENV_REGION' })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('ENV_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
+
+    it 'load AWS_DEFAULT_REGION' do
+      stub_const('ENV', { 'AWS_DEFAULT_REGION' => 'ENV_DEFAULT_REGION' })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('ENV_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
+
+    it 'load AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY' do
+      stub_const('ENV', {
+                   'AWS_ACCESS_KEY_ID' => 'ENV_ACCESS_KEY_ID',
+                   'AWS_SECRET_ACCESS_KEY' => 'ENV_SECRET_ACCESS_KEY'
+                 })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('ENV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('ENV_SECRET_ACCESS_KEY')
+    end
   end
 
-  it 'export AWS_PROIFLE' do
-    stub_const('ENV', { 'AWS_PROFILE' => 'dev' })
-    Awsecrets.load(profile: nil)
-    expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
-    expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
-    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
-  end
+  context 'Precedence' do
+    it '--profile option > AWS_PROFILE' do
+      stub_const('ENV', { 'AWS_PROFILE' => 'production' })
+      Awsecrets.load(profile: 'dev')
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+    end
 
-  it 'secrets.yml' do
-    Awsecrets.load(profile: nil, secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
-    expect(Aws.config[:region]).to eq('YAML_REGION')
-    expect(Aws.config[:credentials].credentials.access_key_id).to eq('YAML_ACCESS_KEY_ID')
-    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('YAML_SECRET_ACCESS_KEY')
+    it '--profile option > AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY' do
+      stub_const('ENV', {
+                   'AWS_ACCESS_KEY_ID' => 'ENV_ACCESS_KEY_ID',
+                   'AWS_SECRET_ACCESS_KEY' => 'ENV_SECRET_ACCESS_KEY'
+                 })
+      Awsecrets.load(profile: 'dev')
+      expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+    end
+
+    it '--profile option > secrets.yml (No .aws/config)' do
+      Awsecrets.load(profile: 'dev', secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
+      expect(Aws.config[:region]).to eq('YAML_REGION') # !!!
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
+    end
+
+    it '--profile option > secrets.yml' do
+      Awsecrets.load(profile: 'production', secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
+      expect(Aws.config[:region]).to eq('CONFIG_PRODUCTION_REGION') # !!!
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_PRODUCTION_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_PRODUCTION_SECRET_ACCESS_KEY')
+    end
+    
+    it '--region option > AWS_REGION' do
+      stub_const('ENV', { 'AWS_REGION' => 'ENV_REGION' })
+      Awsecrets.load(region: 'OPTION_REGION')
+      expect(Aws.config[:region]).to eq('OPTION_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
+
+    it 'AWS_REGION > AWS_DEFAULT_REGION' do
+      stub_const('ENV', {
+                   'AWS_REGION' => 'ENV_REGION',
+                   'AWS_DEFAULT_REGION' => 'ENV_DEFAULT_REGION',
+                 })
+      Awsecrets.load
+      expect(Aws.config[:region]).to eq('ENV_REGION')
+      expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEFAULT_ACCESS_KEY_ID')
+      expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEFAULT_SECRET_ACCESS_KEY')
+    end
   end
 end

--- a/spec/awsecrets_spec.rb
+++ b/spec/awsecrets_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pp'
 
 describe Awsecrets do
   let(:fixtures_path) do

--- a/spec/awsecrets_spec.rb
+++ b/spec/awsecrets_spec.rb
@@ -114,7 +114,7 @@ describe Awsecrets do
       expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_PRODUCTION_ACCESS_KEY_ID')
       expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_PRODUCTION_SECRET_ACCESS_KEY')
     end
-    
+
     it '--region option > AWS_REGION' do
       stub_const('ENV', { 'AWS_REGION' => 'ENV_REGION' })
       Awsecrets.load(region: 'OPTION_REGION')
@@ -126,7 +126,7 @@ describe Awsecrets do
     it 'AWS_REGION > AWS_DEFAULT_REGION' do
       stub_const('ENV', {
                    'AWS_REGION' => 'ENV_REGION',
-                   'AWS_DEFAULT_REGION' => 'ENV_DEFAULT_REGION',
+                   'AWS_DEFAULT_REGION' => 'ENV_DEFAULT_REGION'
                  })
       Awsecrets.load
       expect(Aws.config[:region]).to eq('ENV_REGION')

--- a/spec/awsecrets_spec.rb
+++ b/spec/awsecrets_spec.rb
@@ -17,22 +17,22 @@ describe Awsecrets do
 
   it '--profile option' do
     Awsecrets.load(profile: 'dev')
-    expect(Aws.config[:region]).to eq('ap-northeast-1')
-    expect(Aws.config[:credentials].credentials.access_key_id).to eq('DEV_ACCESS_KEY_ID')
-    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('DEV_SECRET_ACCESS_KEY')
+    expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+    expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
   end
 
   it 'export AWS_PROIFLE' do
     stub_const('ENV', { 'AWS_PROFILE' => 'dev' })
     Awsecrets.load(profile: nil)
-    expect(Aws.config[:region]).to eq('ap-northeast-1')
-    expect(Aws.config[:credentials].credentials.access_key_id).to eq('DEV_ACCESS_KEY_ID')
-    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('DEV_SECRET_ACCESS_KEY')
+    expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
+    expect(Aws.config[:credentials].credentials.access_key_id).to eq('CREDS_DEV_ACCESS_KEY_ID')
+    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
   end
 
   it 'secrets.yml' do
     Awsecrets.load(profile: nil, secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
-    expect(Aws.config[:region]).to eq('ap-northeast-1')
+    expect(Aws.config[:region]).to eq('YAML_REGION')
     expect(Aws.config[:credentials].credentials.access_key_id).to eq('YAML_ACCESS_KEY_ID')
     expect(Aws.config[:credentials].credentials.secret_access_key).to eq('YAML_SECRET_ACCESS_KEY')
   end

--- a/spec/awsecrets_spec.rb
+++ b/spec/awsecrets_spec.rb
@@ -1,7 +1,39 @@
 require 'spec_helper'
 
 describe Awsecrets do
+  let(:fixtures_path) do
+    File.expand_path(File.join(File.dirname(__FILE__), 'fixtures'))
+  end
+
+  before(:each) do
+    stub_const('ENV', {})
+    AWSConfig.config_file = File.expand_path(File.join(fixtures_path, '.aws', 'config'))
+    allow(Dir).to receive(:home).and_return(fixtures_path)
+  end
+
   it 'has a version number' do
     expect(Awsecrets::VERSION).not_to be nil
+  end
+
+  it '--profile option' do
+    Awsecrets.load(profile: 'dev')
+    expect(Aws.config[:region]).to eq('ap-northeast-1')
+    expect(Aws.config[:credentials].credentials.access_key_id).to eq('DEV_ACCESS_KEY_ID')
+    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('DEV_SECRET_ACCESS_KEY')
+  end
+
+  it 'export AWS_PROIFLE' do
+    stub_const('ENV', { 'AWS_PROFILE' => 'dev' })
+    Awsecrets.load(profile: nil)
+    expect(Aws.config[:region]).to eq('ap-northeast-1')
+    expect(Aws.config[:credentials].credentials.access_key_id).to eq('DEV_ACCESS_KEY_ID')
+    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('DEV_SECRET_ACCESS_KEY')
+  end
+
+  it 'secrets.yml' do
+    Awsecrets.load(profile: nil, secrets_path: File.expand_path(File.join(fixtures_path, 'secrets.yml')))
+    expect(Aws.config[:region]).to eq('ap-northeast-1')
+    expect(Aws.config[:credentials].credentials.access_key_id).to eq('YAML_ACCESS_KEY_ID')
+    expect(Aws.config[:credentials].credentials.secret_access_key).to eq('YAML_SECRET_ACCESS_KEY')
   end
 end

--- a/spec/fixtures/.aws/config
+++ b/spec/fixtures/.aws/config
@@ -1,0 +1,3 @@
+[default]
+output = json
+region = ap-northeast-1

--- a/spec/fixtures/.aws/config
+++ b/spec/fixtures/.aws/config
@@ -1,3 +1,7 @@
 [default]
 output = json
-region = ap-northeast-1
+region = CONFIG_DEFAULT_REGION
+
+[profile production]
+output = json
+region = CONFIG_PRODUCTION_REGION

--- a/spec/fixtures/.aws/credentials
+++ b/spec/fixtures/.aws/credentials
@@ -1,0 +1,11 @@
+[default]
+aws_access_key_id = DEFAULT_ACCESS_KEY_ID
+aws_secret_access_key = DEFAULT_SECRET_ACCESS_KEY
+
+[dev]
+aws_access_key_id = DEV_ACCESS_KEY_ID
+aws_secret_access_key = DEV_SECRET_ACCESS_KEY
+
+[production]
+aws_access_key_id = PRODUCTION_ACCESS_KEY_ID
+aws_secret_access_key = PRODUCTION_SECRET_ACCESS_KEY

--- a/spec/fixtures/.aws/credentials
+++ b/spec/fixtures/.aws/credentials
@@ -1,11 +1,11 @@
 [default]
-aws_access_key_id = DEFAULT_ACCESS_KEY_ID
-aws_secret_access_key = DEFAULT_SECRET_ACCESS_KEY
+aws_access_key_id = CREDS_DEFAULT_ACCESS_KEY_ID
+aws_secret_access_key = CREDS_DEFAULT_SECRET_ACCESS_KEY
 
 [dev]
-aws_access_key_id = DEV_ACCESS_KEY_ID
-aws_secret_access_key = DEV_SECRET_ACCESS_KEY
+aws_access_key_id = CREDS_DEV_ACCESS_KEY_ID
+aws_secret_access_key = CREDS_DEV_SECRET_ACCESS_KEY
 
 [production]
-aws_access_key_id = PRODUCTION_ACCESS_KEY_ID
-aws_secret_access_key = PRODUCTION_SECRET_ACCESS_KEY
+aws_access_key_id = CREDS_PRODUCTION_ACCESS_KEY_ID
+aws_secret_access_key = CREDS_PRODUCTION_SECRET_ACCESS_KEY

--- a/spec/fixtures/secrets.yml
+++ b/spec/fixtures/secrets.yml
@@ -1,0 +1,3 @@
+region: ap-northeast-1
+aws_access_key_id: YAML_ACCESS_KEY_ID
+aws_secret_access_key: YAML_SECRET_ACCESS_KEY

--- a/spec/fixtures/secrets.yml
+++ b/spec/fixtures/secrets.yml
@@ -1,3 +1,3 @@
-region: ap-northeast-1
+region: YAML_REGION
 aws_access_key_id: YAML_ACCESS_KEY_ID
 aws_secret_access_key: YAML_SECRET_ACCESS_KEY


### PR DESCRIPTION
http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence

## awsecrets config precedence

1. Command Line Options
2. Environment Variables
3. YAML file (secrets.yml)
4. The AWS credentials file
5. The CLI configuration file