### PR TITLE
Depend only on aws-sdk-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Create command line tool `ec2sample` like following code
 ```ruby
 #!/usr/bin/env ruby
 require 'awsecrets'
+require 'aws-sdk-ec2'
 Awsecrets.load
 ec2_client = Aws::EC2::Client.new
 puts ec2_client.describe_instances({ instance_ids: [ARGV.first] }).reservations.first.instances.first

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'aws-sdk', '>= 2', '< 4'
+  spec.add_runtime_dependency 'aws-sdk-core', '>= 3', '< 4'
   spec.add_runtime_dependency 'aws_config', '~> 0.1.0'
   spec.add_development_dependency 'bundler', '~> 1.9'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -1,6 +1,6 @@
 require_relative 'awsecrets/version'
 require 'optparse'
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'aws_config'
 require 'net/http'
 require 'yaml'


### PR DESCRIPTION
The aws-sdk dependency pulls in a large number of otherwise unnecessary AWS SDKs. Restrict this module's runtime dependency to just aws-sdk-core.