### PR TITLE
Depend only on aws-sdk-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in awsecrets.gemspec

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Create a command line tool `ec2sample` like following code:
 ```ruby
 #!/usr/bin/env ruby
 require 'awsecrets'
+require 'aws-sdk-ec2'
 Awsecrets.load
 ec2_client = Aws::EC2::Client.new
 puts ec2_client.describe_instances({ instance_ids: [ARGV.first] }).reservations.first.instances.first

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 
 begin

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'aws-sdk', '>= 2', '< 4'
+  spec.add_runtime_dependency 'aws-sdk-core', '>= 2', '< 4'
   spec.add_runtime_dependency 'aws_config', '~> 0.1.0'
   spec.add_development_dependency 'bundler', '>= 1.9', '< 3.0'
   spec.add_development_dependency 'octorelease'

--- a/bin/console
+++ b/bin/console
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'bundler/setup'
 require 'awsecrets'

--- a/bin/testcommand
+++ b/bin/testcommand
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require_relative '../lib/awsecrets'
 
 Awsecrets.load

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 require_relative 'awsecrets/version'
 require 'optparse'
-require 'aws-sdk'
+require 'aws-sdk-core'
 require 'aws_config'
 require 'net/http'
 require 'yaml'
@@ -38,6 +40,7 @@ module Awsecrets
 
   def self.load_method_args
     return false unless @profile
+
     @region ||= AWSConfig[@profile]['region'] if AWSConfig[@profile]['region']
     true
   end
@@ -63,7 +66,8 @@ module Awsecrets
     @secrets_path ||= ENV['AWS_SECRETS_PATH']
     return true if @access_key_id
     return unless ENV['AWS_ACCESS_KEY_ID'] && ENV['AWS_SECRET_ACCESS_KEY']
-    @access_key_id     ||= ENV['AWS_ACCESS_KEY_ID']
+
+    @access_key_id ||= ENV['AWS_ACCESS_KEY_ID']
     @secret_access_key ||= ENV['AWS_SECRET_ACCESS_KEY']
     @session_token     ||= ENV['AWS_SESSION_TOKEN']
     true

--- a/lib/awsecrets/version.rb
+++ b/lib/awsecrets/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Awsecrets
   VERSION = '1.14.0'
 end


### PR DESCRIPTION
The aws-sdk dependency pulls in a large number of otherwise unnecessary AWS SDKs. Restrict this module's runtime dependency to just aws-sdk-core.