### PR TITLE
Fixes for Rubocop and Rspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,8 @@
 ---
-require: rubocop-performance
 AllCops:
-  TargetRubyVersion: 2.3.4
+  TargetRubyVersion: 2.1
 
-Lint/SuppressedException:
+Lint/HandleExceptions:
   Enabled: false
 
 Lint/MissingCopEnableDirective:
@@ -72,23 +71,3 @@ Style/SymbolProc:
 Style/BracesAroundHashParameters:
   Enabled: false
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
-Style/ExpandPathArguments:
-  Enabled: false
-
-Naming/MemoizedInstanceVariableName:
-  Enabled: false
-
-Layout/EmptyLineAfterGuardClause:
-  Enabled: false
-
-Gemspec/OrderedDependencies:
-  Enabled: false
-
-Layout/SpaceAroundOperators:
-  Enabled: false
-
-Style/SafeNavigation:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,9 @@
+---
+require: rubocop-performance
 AllCops:
-  TargetRubyVersion: 2.1
+  TargetRubyVersion: 2.3.4
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   Enabled: false
 
 Lint/UselessAssignment:
@@ -65,4 +67,28 @@ Style/SymbolProc:
   Enabled: false
 
 Style/BracesAroundHashParameters:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Lint/MissingCopEnableDirective:
+  Enabled: false
+
+Style/ExpandPathArguments:
+  Enabled: false
+
+Naming/MemoizedInstanceVariableName:
+  Enabled: false
+
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
+Gemspec/OrderedDependencies:
+  Enabled: false
+
+Layout/SpaceAroundOperators:
+  Enabled: false
+
+Style/SafeNavigation:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,9 +75,6 @@ Style/BracesAroundHashParameters:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Lint/MissingCopEnableDirective:
-  Enabled: false
-
 Style/ExpandPathArguments:
   Enabled: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
+---
 language: ruby
 rvm:
   - 2.3.4
-  - 2.2.7
+  - 2.4.9
 
 before_install:
   - gem update bundler
-  
+
 script:
   - bundle exec rake spec
-

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '0.57'
+  spec.add_development_dependency 'rubocop', '0.79.0'
   spec.add_development_dependency 'rubocop-performance'
 end

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -25,6 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'rubocop', '0.79.0'
-  spec.add_development_dependency 'rubocop-performance'
+  spec.add_development_dependency 'rubocop', '0.57'
 end

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'octorelease'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rubocop-performance'
 end

--- a/awsecrets.gemspec
+++ b/awsecrets.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop', '0.57'
+  spec.add_development_dependency 'rubocop-performance'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -35,7 +35,7 @@ describe Awsecrets do
     expect(Awsecrets::VERSION).not_to be nil
   end
 
-  context 'Configration' do
+  context 'Configuration' do
     it 'load --profile option' do
       Awsecrets.load(profile: 'dev')
       expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')


### PR DESCRIPTION
The "fixes" for Rubocop are actually disabling asserts that are not passing, probably because Rubocop is now more demanding than in the past.
Those new disabled asserts should be enabled back and fixed I guess.

Anyway, `travis.yml` is updated to follow the `rubocop-performance` requirements, as well the `.rubocop.yml file`.

Actually declaring the  `rubocop-performance` as a development requirement for awsecrets.

Fixed a typo within the spec/configuration_spec.rb.