### PR TITLE
Added Aws::EC2::Client config checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,28 @@ Or install it yourself as:
 
 ## Usage example
 
-Create command line tool `ec2sample` like following code
+### Generate exception with wrong configuration
+
+For some use cases, awsecrets might raise an exception if (even after all
+attempts to configure access to an AWS account) there is missing configuration
+parameters.
+
+In other cases, this might not be desired.
+
+To have control on that, you can use the environment variable
+`DISABLE_AWS_CLIENT_CHECK`: if you set it to the string `'true'`, it will not
+attempt to early create an `Aws::EC2::Client` instance with the found
+parameters.
+
+By default, even if you don't set `DISABLE_AWS_CLIENT_CHECK` it will be treated
+like `true`.
+
+To enable this early checking, you **must** setup `DISABLE_AWS_CLIENT_CHECK`
+with the string `'false'`.
+
+### Basic example
+
+Create a command line tool `ec2sample` like following code:
 
 ```ruby
 #!/usr/bin/env ruby
@@ -41,17 +62,21 @@ ec2_client = Aws::EC2::Client.new
 puts ec2_client.describe_instances({ instance_ids: [ARGV.first] }).reservations.first.instances.first
 ```
 
-And execute
+Then execute it with command line parameters:
 
 ```sh
 $ ec2sample i-1aa1aaaa --profile mycreds --region ap-northeast-1
+```
 
-or
+or with environment variables configuration:
 
+```sh
 $ AWS_ACCESS_KEY_ID=XXXXXXXXXXXXXXXXXXXX AWS_SECRET_ACCESS_KEY=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX AWS_REGION=ap-northeast-1 ec2sample i-1aa1aaaa
+```
 
-or
+or using an YAML file:
 
+```sh
 $ cat <<EOF > secrets.yml
 region: ap-northeast-1
 aws_access_key_id: XXXXXXXXXXXXXXXXXXXX
@@ -64,7 +89,7 @@ $ ec2sample i-1aa1aaaa
 
 Support `role_arn` `role_session_name` `source_profile` `external_id`.
 
-#### 1. .aws/config and .aws/credentials
+#### 1. `.aws/config` and `.aws/credentials`
 
 see http://docs.aws.amazon.com/cli/latest/userguide/cli-roles.html
 
@@ -89,7 +114,7 @@ And execute
 $ ec2sample i-1aa1aaaa --profile assumed --region ap-northeast-1
 ```
 
-#### 2. secrets.yml
+#### 2. `secrets.yml`
 
 ```sh
 $ cat <<EOF > secrets.yml
@@ -105,7 +130,7 @@ And execute
 $ ec2sample i-1aa1aaaa
 ```
 
-### Disable load YAML(secrets.yml)
+### Disable load YAML (`secrets.yml`)
 
 ```ruby
 Awsecrets.load(disable_load_secrets:true)
@@ -119,8 +144,8 @@ Awsecrets.load(secrets_path:false)
 
 ## Contributing
 
-1. Fork it ( https://github.com/k1LoW/awsecrets/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+1. [Fork it]( https://github.com/k1LoW/awsecrets/fork )!
+2. Create your feature branch (`git checkout -b my-new-feature`).
+3. Commit your changes (`git commit -am 'Add some feature'`).
+4. Push to the branch (`git push origin my-new-feature`).
+5. Create a new Pull Request.

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -141,23 +141,6 @@ module Awsecrets
     Aws.config[:credentials] = @credentials
   end
 
-<<<<<<< HEAD
-=======
-  def self.generate_session_name
-    "awsecrets-session-#{Time.now.to_i}"
-  end
-
-  def self.current_region
-    metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
-    begin
-      az = Net::HTTP.get(URI.parse(metadata_endpoint + 'placement/availability-zone'))
-      az[0...-1]
-    rescue Errno::EHOSTUNREACH => e
-      STDERR.puts "Attemped but failed to recover AWS configuration from EC2-like metadata: #{e}"
-    end
-  end
-
->>>>>>> master
   def self.role_creds(args)
     Aws::AssumeRoleCredentials.new(args)
   end

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -140,18 +140,20 @@ module Awsecrets
     @credentials ||= Aws::SharedCredentials.new(profile_name: 'default') if AWSConfig['default'] && !@access_key_id
     @credentials ||= Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token) if @access_key_id
     @credentials ||= Aws::InstanceProfileCredentials.new
-
-    if ENV.key?('DISABLE_AWS_CLIENT_CHECK') && !ENV['DISABLE_AWS_CLIENT_CHECK'].nil? && (ENV['DISABLE_AWS_CLIENT_CHECK'] == 'false')
-      begin
-        Aws::EC2::Client.new
-      rescue Aws::Errors::MissingRegionError
-        raise 'Missing region: use the region command line option or export region name to ENV[\'AWS_REGION\'] or use the awscli configuration'
-      rescue StandardError => e
-        raise "Oops, there is something wrong with AWS client configuration => #{e}"
-      end
-    end
-
+    self.validate_client
     Aws.config[:credentials] = @credentials
+  end
+
+  def self.validate_client
+    return unless ENV.key?('DISABLE_AWS_CLIENT_CHECK') && (ENV['DISABLE_AWS_CLIENT_CHECK'] == 'false')
+
+    begin
+      Aws::EC2::Client.new
+    rescue Aws::Errors::MissingRegionError
+      raise 'Missing region: use "region" command line option or export ENV[\'AWS_REGION\'] or awscli configure'
+    rescue StandardError => e
+      raise "Oops, there is something wrong with AWS client configuration => #{e}"
+    end
   end
 
   def self.generate_session_name

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -138,6 +138,16 @@ module Awsecrets
     @credentials ||= Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token) if @access_key_id
     @credentials ||= Aws::InstanceProfileCredentials.new
 
+    if ENV.key?('DISABLE_AWS_CLIENT_CHECK') && !ENV['DISABLE_AWS_CLIENT_CHECK'].nil? && (ENV['DISABLE_AWS_CLIENT_CHECK'] == 'false')
+      begin
+        Aws::EC2::Client.new
+      rescue Aws::Errors::MissingRegionError
+        raise 'Missing region: use the region command line option or export region name to ENV[\'AWS_REGION\'] or use the awscli configuration'
+      rescue StandardError => e
+        raise "Oops, there is something wrong with AWS client configuration => #{e}"
+      end
+    end
+
     Aws.config[:credentials] = @credentials
   end
 

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -1,11 +1,13 @@
 require_relative 'awsecrets/version'
+require_relative 'awsecrets/utils'
 require 'optparse'
 require 'aws-sdk'
 require 'aws_config'
-require 'net/http'
 require 'yaml'
 
 module Awsecrets
+  include Misc
+
   def self.load(profile: nil, region: nil, secrets_path: nil, disable_load_secrets: false)
     @profile              = profile
     @region               = region
@@ -13,14 +15,8 @@ module Awsecrets
     @disable_load_secrets = disable_load_secrets
     @disable_load_secrets = true if secrets_path == false
 
-    @credentials       = nil
-    @access_key_id     = nil
-    @secret_access_key = nil
-    @session_token     = nil
-    @role_arn          = nil
-    @external_id       = nil
-    @source_profile    = nil
-    @role_session_name = nil
+    @credentials = @access_key_id = @secret_access_key = @session_token = nil
+    @role_arn = @external_id = @source_profile = @role_session_name = nil
 
     # 1. Command Line Options
     load_options if load_method_args
@@ -86,7 +82,7 @@ module Awsecrets
     @role_session_name ||= creds['role_session_name'] if creds.include?('role_session_name')
 
     return true unless @role_arn
-    @role_session_name ||= generate_session_name
+    @role_session_name ||= Misc.generate_session_name
     @credentials ||= role_creds(
       client: Aws::STS::Client.new(
         region: @region,
@@ -118,7 +114,7 @@ module Awsecrets
     Aws.config[:region] = @region
 
     if @role_arn && @source_profile
-      @role_session_name ||= generate_session_name
+      @role_session_name ||= Misc.generate_session_name
       region = if AWSConfig[@source_profile.name] && AWSConfig[@source_profile.name]['region']
                  AWSConfig[@source_profile.name]['region']
                else
@@ -140,30 +136,9 @@ module Awsecrets
     @credentials ||= Aws::SharedCredentials.new(profile_name: 'default') if AWSConfig['default'] && !@access_key_id
     @credentials ||= Aws::Credentials.new(@access_key_id, @secret_access_key, @session_token) if @access_key_id
     @credentials ||= Aws::InstanceProfileCredentials.new
-    self.validate_client
+
+    Misc.validate_client
     Aws.config[:credentials] = @credentials
-  end
-
-  def self.validate_client
-    return unless ENV.key?('DISABLE_AWS_CLIENT_CHECK') && (ENV['DISABLE_AWS_CLIENT_CHECK'] == 'false')
-
-    begin
-      Aws::EC2::Client.new
-    rescue Aws::Errors::MissingRegionError
-      raise 'Missing region: use "region" command line option or export ENV[\'AWS_REGION\'] or awscli configure'
-    rescue StandardError => e
-      raise "Oops, there is something wrong with AWS client configuration => #{e}"
-    end
-  end
-
-  def self.generate_session_name
-    "awsecrets-session-#{Time.now.to_i}"
-  end
-
-  def self.current_region
-    metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
-    az = Net::HTTP.get(URI.parse(metadata_endpoint + 'placement/availability-zone'))
-    az[0...-1]
   end
 
   def self.role_creds(args)

--- a/lib/awsecrets/utils.rb
+++ b/lib/awsecrets/utils.rb
@@ -1,0 +1,25 @@
+require 'net/http'
+
+module Misc
+  def self.validate_client
+    return unless ENV.key?('DISABLE_AWS_CLIENT_CHECK') && (ENV['DISABLE_AWS_CLIENT_CHECK'] == 'false')
+
+    begin
+      Aws::EC2::Client.new
+    rescue Aws::Errors::MissingRegionError
+      raise 'Missing region: use "region" command line option or export ENV[\'AWS_REGION\'] or awscli configure'
+    rescue StandardError => e
+      raise "Oops, there is something wrong with AWS client configuration => #{e}"
+    end
+  end
+
+  def self.generate_session_name
+    "awsecrets-session-#{Time.now.to_i}"
+  end
+
+  def self.current_region
+    metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
+    az = Net::HTTP.get(URI.parse(metadata_endpoint + 'placement/availability-zone'))
+    az[0...-1]
+  end
+end

--- a/spec/configration_spec.rb
+++ b/spec/configration_spec.rb
@@ -75,7 +75,7 @@ describe Awsecrets do
       expect(Aws.config[:credentials].credentials.session_token).to eq('YAML_SESSION_TOKEN')
     end
 
-    it 'load AWS_PROIFLE' do
+    it 'load AWS_PROFILE' do
       stub_const('ENV', { 'AWS_PROFILE' => 'dev' })
       Awsecrets.load
       expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
@@ -83,7 +83,7 @@ describe Awsecrets do
       expect(Aws.config[:credentials].credentials.secret_access_key).to eq('CREDS_DEV_SECRET_ACCESS_KEY')
     end
 
-    it 'load AWS_DEFAULT_PROIFLE' do
+    it 'load AWS_DEFAULT_PROFILE' do
       stub_const('ENV', { 'AWS_DEFAULT_PROFILE' => 'default' })
       Awsecrets.load
       expect(Aws.config[:region]).to eq('CONFIG_DEFAULT_REGION')
@@ -191,7 +191,7 @@ describe Awsecrets do
         end
       end
 
-      it 'load AWS_PROIFLE=assumed_no_session_name' do
+      it 'load AWS_PROFILE=assumed_no_session_name' do
         stub_const('ENV', { 'AWS_PROFILE' => 'assumed_no_session_name' })
         Awsecrets.load
         expect(Aws.config[:region]).to eq('CONFIG-ASSUME-TEST-REGION')


### PR DESCRIPTION
If the environment variable `DISABLE_AWS_CLIENT_CHECK` is properly configured, now awsecrets will attempt to create an `Aws::EC2::Client.new` (discarding it latter) in order to validate if all configuration parameters are in place.
Documentation updated to reflect that.
Since that by default this will not change the previous behavior, the change should not have any impact clients unaware of `DISABLE_AWS_CLIENT_CHECK` environment variable.