### PR TITLE
Changed exception to error message

### DIFF
--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -13,9 +13,7 @@ module Awsecrets
     @disable_load_secrets = disable_load_secrets
     @disable_load_secrets = true if secrets_path == false
 
-    @credentials       = nil
-    @access_key_id     = nil
-    @secret_access_key = nil
+    @secret_access_key = @credentials = @access_key_id = nil
     @session_token     = nil
     @role_arn          = nil
     @external_id       = nil

--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -147,8 +147,12 @@ module Awsecrets
 
   def self.current_region
     metadata_endpoint = 'http://169.254.169.254/latest/meta-data/'
-    az = Net::HTTP.get(URI.parse(metadata_endpoint + 'placement/availability-zone'))
-    az[0...-1]
+    begin
+      az = Net::HTTP.get(URI.parse(metadata_endpoint + 'placement/availability-zone'))
+      az[0...-1]
+    rescue Errno::EHOSTUNREACH => e
+      STDERR.puts "Attemped but failed to recover AWS configuration from EC2-like metadata: #{e}"
+    end
   end
 
   def self.role_creds(args)


### PR DESCRIPTION
Instead of raising a timeout exception when trying to reach AWS EC2 metadata, now the attempted will only generate an error message into `STDERR`.