### PR TITLE
Fix region assignment via Misc class when nil

### DIFF
--- a/lib/awsecrets.rb
+++ b/lib/awsecrets.rb
@@ -110,7 +110,7 @@ module Awsecrets
   end
 
   def self.set_aws_config
-    @region ||= self.current_region
+    @region ||= Misc.current_region
     Aws.config[:region] = @region
 
     if @role_arn && @source_profile


### PR DESCRIPTION
The call to current_region is now done on Misc. This case is currently not caught by the tests.